### PR TITLE
Update reminder command description and usage examples

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,10 @@ jobs:
       -
         run: "cp ~/repo/api/.keys.json ~/repo/api/keys.json"
       -
+        run:
+          name: Wait for db
+          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+      -
         run: "npm run db_init"
       -
         run: "npm run test"

--- a/api/commands/reminders/remind.js
+++ b/api/commands/reminders/remind.js
@@ -20,11 +20,11 @@ const command = {
   name: 'remind',
   group: 'reminders',
   memberName: 'remind',
-  description: 'Set a new reminder.',
-  examples: ['rbot remind @user "Buy milk" tomorrow',
-    'rbot remind @user "Pick up the dog" in 4 hours',
-    'rbot remind @user take the trash out at 6pm',
-    'rbot remind @user renew driver license in 2 weeks'],
+  description: 'Set a new reminder. When using the one-line/short-hand ' +
+    'version of this command, enclose the reminder task in double quotes ' +
+    'for more accurate parsing. See examples below: ',
+  examples: ['rbot remind @user "Tell Kiba he\'s a good boy" tomorrow morning',
+    'rbot remind @user "Pick up the dog" in 4 hours'],
   args: [
     {
       key: 'target',


### PR DESCRIPTION
While this [issue](https://github.com/jnhallquist/discord-reminders-bot/issues/35) is being investigated, this PR provides a temp fix.

The reminder command description has been updated to suggest that users use double quotes in their inputs.