### PR TITLE
Add job_ids column to users

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS public.users
     username varchar COLLATE pg_catalog."default" NOT NULL,
     username_discriminator varchar COLLATE pg_catalog."default" NOT NULL,
     timezone text COLLATE pg_catalog."default" NOT NULL,
-    job_ids text[] COLLATE pg_catalog."default" NOT NULL,
+    job_ids text[] COLLATE pg_catalog."default",
     CONSTRAINT user_timezones_pkey PRIMARY KEY (id),
     CONSTRAINT username_discriminator UNIQUE (username_discriminator)
 )

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -11,9 +11,10 @@ ALTER SEQUENCE public.id_seq
 CREATE TABLE IF NOT EXISTS public.users
 (
     id bigint NOT NULL DEFAULT nextval('id_seq'::regclass),
-    username text COLLATE pg_catalog."default" NOT NULL,
-    username_discriminator text COLLATE pg_catalog."default" NOT NULL,
+    username varchar COLLATE pg_catalog."default" NOT NULL,
+    username_discriminator varchar COLLATE pg_catalog."default" NOT NULL,
     timezone text COLLATE pg_catalog."default" NOT NULL,
+    job_ids text[] COLLATE pg_catalog."default" NOT NULL,
     CONSTRAINT user_timezones_pkey PRIMARY KEY (id),
     CONSTRAINT username_discriminator UNIQUE (username_discriminator)
 )


### PR DESCRIPTION
This PR updates the db schema to add a job_ids column to the users table.

A future PR will generate job ids for all new jobs. We will store them in the table to provide for job retrieval later.