### PR TITLE
Fix json parse error

### DIFF
--- a/api/redis/processReminders.js
+++ b/api/redis/processReminders.js
@@ -33,13 +33,13 @@ const getReminders = (expiredTimestampsArray) => {
 
   return Promise.all(remindersToGet).then((reminders) => {
     let remindersToSend = [];
-    let tempArray;
 
     if (reminders.length > 0) {
-      reminders.forEach((item) => {
-        tempArray = JSON.parse(item);
-        tempArray.forEach((tempItem) => {
-          remindersToSend.push(tempItem);
+      reminders.forEach((arrayOfReminders) => {
+        let parsedArrayOfReminders = JSON.parse(arrayOfReminders);
+
+        parsedArrayOfReminders.forEach((parsedReminder) => {
+          remindersToSend.push(parsedReminder);
         });
       })
     }

--- a/api/redis/processReminders.js
+++ b/api/redis/processReminders.js
@@ -62,10 +62,12 @@ const sendReminders = (remindersArray, timestampsToClearArray) => {
 
 const processReminders = () => {
   return scanReminderStore().then((allTimestamps) => {
+    console.log(1, allTimestamps);
     if (allTimestamps.length > 0) {
       const expiredTimestamps = getExpiredTimestamps(allTimestamps);
-
+      console.log(2, expiredTimestamps);
       return getReminders(expiredTimestamps).then((res) => {
+        console.log(3, res);
         if (res[0].length > 0) {
           sendReminders(...res);
         }

--- a/api/redis/processReminders.js
+++ b/api/redis/processReminders.js
@@ -35,13 +35,8 @@ const getReminders = (expiredTimestampsArray) => {
     let remindersToSend = [];
 
     if (reminders.length > 0) {
-      reminders.forEach((arrayOfReminders) => {
-        let parsedArrayOfReminders = JSON.parse(arrayOfReminders);
-
-        parsedArrayOfReminders.forEach((parsedReminder) => {
-          remindersToSend.push(parsedReminder);
-        });
-      })
+      reminders.forEach(arrayOfReminders =>
+        remindersToSend.push(...JSON.parse(arrayOfReminders)));
     }
 
     return [remindersToSend, timestampsToClear];

--- a/api/redis/processReminders.js
+++ b/api/redis/processReminders.js
@@ -62,12 +62,10 @@ const sendReminders = (remindersArray, timestampsToClearArray) => {
 
 const processReminders = () => {
   return scanReminderStore().then((allTimestamps) => {
-    console.log(1, allTimestamps);
     if (allTimestamps.length > 0) {
       const expiredTimestamps = getExpiredTimestamps(allTimestamps);
-      console.log(2, expiredTimestamps);
+
       return getReminders(expiredTimestamps).then((res) => {
-        console.log(3, res);
         if (res[0].length > 0) {
           sendReminders(...res);
         }

--- a/api/redis/processReminders.js
+++ b/api/redis/processReminders.js
@@ -35,8 +35,9 @@ const getReminders = (expiredTimestampsArray) => {
     let remindersToSend = [];
 
     if (reminders.length > 0) {
-      reminders.forEach(arrayOfReminders =>
-        remindersToSend.push(...JSON.parse(arrayOfReminders)));
+      reminders.forEach((arrayOfReminders) => {
+        remindersToSend.push(...JSON.parse(arrayOfReminders));
+      });
     }
 
     return [remindersToSend, timestampsToClear];

--- a/api/redis/processReminders.js
+++ b/api/redis/processReminders.js
@@ -33,9 +33,15 @@ const getReminders = (expiredTimestampsArray) => {
 
   return Promise.all(remindersToGet).then((reminders) => {
     let remindersToSend = [];
+    let tempArray;
 
     if (reminders.length > 0) {
-      remindersToSend = JSON.parse(reminders);
+      reminders.forEach((item) => {
+        tempArray = JSON.parse(item);
+        tempArray.forEach((tempItem) => {
+          remindersToSend.push(tempItem);
+        });
+      })
     }
 
     return [remindersToSend, timestampsToClear];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-reminders-bot",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -21,9 +21,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
+      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -42,16 +42,16 @@
       "dev": true
     },
     "chai": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
-      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "requires": {
-        "assertion-error": "^1.0.1",
-        "check-error": "^1.0.1",
-        "deep-eql": "^3.0.0",
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
         "get-func-name": "^2.0.0",
-        "pathval": "^1.0.0",
-        "type-detect": "^4.0.0"
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
       }
     },
     "check-error": {
@@ -108,12 +108,12 @@
       "dev": true
     },
     "discord.js": {
-      "version": "11.3.2",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-11.3.2.tgz",
-      "integrity": "sha512-Abw9CTMX3Jb47IeRffqx2VNSnXl/OsTdQzhvbw/JnqCyqc2imAocc7pX2HoRmgKd8CgSqsjBFBneusz/E16e6A==",
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-11.4.2.tgz",
+      "integrity": "sha512-MDwpu0lMFTjqomijDl1Ed9miMQe6kB4ifKdP28QZllmLv/HVOJXhatRgjS8urp/wBlOfx+qAYSXcdI5cKGYsfg==",
       "requires": {
         "long": "^4.0.0",
-        "prism-media": "^0.0.2",
+        "prism-media": "^0.0.3",
         "snekfetch": "^3.6.4",
         "tweetnacl": "^1.0.0",
         "ws": "^4.0.0"
@@ -279,9 +279,9 @@
       "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
     },
     "moment-timezone": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.17.tgz",
-      "integrity": "sha512-Y/JpVEWIOA9Gho4vO15MTnW1FCmHi3ypprrkUaxsZ1TKg3uqC8q/qMBjTddkHoiwwZN3qvZSr4zJP7x9V3LpXA==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.21.tgz",
+      "integrity": "sha512-j96bAh4otsgj3lKydm3K7kdtA3iKf2m6MY2iSYCzCm5a1zmHo1g+aK3068dDEeocLZQIS9kU8bsdQHLqEvgW0A==",
       "requires": {
         "moment": ">= 2.9.0"
       }
@@ -317,9 +317,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "pathval": {
@@ -328,9 +328,9 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
     },
     "prism-media": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-0.0.2.tgz",
-      "integrity": "sha512-L6yc8P5NVG35ivzvfI7bcTYzqFV+K8gTfX9YaJbmIFfMXTs71RMnAupvTQPTCteGsiOy9QcNLkQyWjAafY/hCQ=="
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-0.0.3.tgz",
+      "integrity": "sha512-c9KkNifSMU/iXT8FFTaBwBMr+rdVcN+H/uNv1o+CuFeTThNZNTOrQ+RgXA1yL/DeLk098duAeRPP3QNPNbhxYQ=="
     },
     "process": {
       "version": "0.11.10",
@@ -338,14 +338,14 @@
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "proxyquire": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.0.1.tgz",
-      "integrity": "sha512-fQr3VQrbdzHrdaDn3XuisVoJlJNDJizHAvUXw9IuXRR8BpV2x0N7LsCxrpJkeKfPbNjiNU/V5vc008cI0TmzzQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.0.tgz",
+      "integrity": "sha512-kptdFArCfGRtQFv3Qwjr10lwbEV0TBJYvfqzhwucyfEXqVgmnAkyEw/S3FYzR5HI9i5QOq4rcqQjZ6AlknlCDQ==",
       "dev": true,
       "requires": {
         "fill-keys": "^1.0.2",
         "module-not-found-error": "^1.0.0",
-        "resolve": "~1.5.0"
+        "resolve": "~1.8.1"
       }
     },
     "redis": {
@@ -374,9 +374,9 @@
       "integrity": "sha1-tEIMIzrAKC0P9Jsnf7iAqLXeCJQ="
     },
     "resolve": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.5"
@@ -388,9 +388,9 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
     },
     "snekfetch": {
       "version": "3.6.4",

--- a/package.json
+++ b/package.json
@@ -19,20 +19,20 @@
   },
   "homepage": "https://github.com/jnhallquist/discord-reminders-bot#readme",
   "dependencies": {
-    "bluebird": "^3.5.1",
-    "chai": "^4.1.2",
+    "bluebird": "^3.5.2",
+    "chai": "^4.2.0",
     "chrono-node": "^1.3.5",
-    "discord.js": "^11.3.2",
+    "discord.js": "^11.4.2",
     "discord.js-commando": "^0.10.0",
     "moment": "^2.22.2",
-    "moment-timezone": "^0.5.17",
+    "moment-timezone": "^0.5.21",
     "path": "^0.12.7",
     "redis": "^2.8.0",
-    "semver": "^5.5.0"
+    "semver": "^5.5.1"
   },
   "devDependencies": {
     "mocha": "^5.2.0",
-    "proxyquire": "^2.0.1"
+    "proxyquire": "^2.1.0"
   },
   "engines": {
     "node": ">= 8.0.0"

--- a/test/commands/reminders/remind.js
+++ b/test/commands/reminders/remind.js
@@ -91,7 +91,7 @@ describe('Remind Command', () => {
 
       it('returns successful reminder creation message', () => {
         return subject(msg, reminder).then((res) => {
-          expect(res).to.contain(`will be reminded "This is a test reminder"`);
+          expect(res.toString()).to.contain(`will be reminded "This is a test reminder"`);
         });
       });
     });


### PR DESCRIPTION
Discovered that when reminders (that are scheduled to fire at different timestamps) are put into queue and the server dies, if the server is restarted after those reminders have already expired, `processReminders()` throws a JSON parsing error.

This was addressed by calling `JSON.parse()` on each item inside `remindersToGet` array instead of on the entire array itself.