### PR TITLE
Add author id to reminder object

### DIFF
--- a/api/commands/reminders/remind.js
+++ b/api/commands/reminders/remind.js
@@ -79,6 +79,7 @@ module.exports = class RemindCommand extends Command {
         }
 
         reminders.push({
+          author: author.id,
           target: target.id,
           parsedTime: parsedTime.parsed,
           content


### PR DESCRIPTION
This PR is a pre-req for fixing this [issue](https://github.com/jnhallquist/discord-reminders-bot/issues/55).

In separate PR, I will refactor `processReminders()` to check whether reminder has expired in author's timezone.